### PR TITLE
docs(#1): rewrite README for readability and scalability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- Rewrite README.md for better readability and scalability (fixes #1)
+- Add Quick Reference table organized by submodule
+- Consolidate feature docs under a single "Feature Documentation" section
+
 ## [0.2.0] - 2026-03-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,14 +13,39 @@ Personal Python utility library — decorators, helpers, classes, and utils.
 pip install jsi-tools
 ```
 
-## Decorators
+## Quick Reference
 
-### `@log_return`
+### Decorators
 
-Logs the return value of a function with type and size information. Zero side effects — the return value is never modified.
+| Name | Description |
+|------|-------------|
+| [`@log_return`](#log_return) | Log a function's return value with type and size info |
+
+### Helpers
+
+| Name | Description |
+|------|-------------|
+| [`diff(a, b)`](#diff) | Compute a structured diff between two collections |
+
+### Classes
+
+*No classes yet.*
+
+### Utils
+
+*No utils yet.*
+
+---
+
+## Feature Documentation
+
+### `log_return`
+
+Logs the return value of a function with type and size information.
+Zero side effects — the return value is never modified.
+Supports sync/async functions, generators, and instance/static/class methods.
 
 ```python
-import logging
 from jsi_tools import log_return
 
 @log_return
@@ -31,16 +56,7 @@ get_users()
 # DEBUG — get_users returned list[len=3]: ['alice', 'bob', 'charlie']
 ```
 
-Works with or without arguments:
-
-```python
-@log_return(level=logging.INFO, max_length=50)
-def fetch_config():
-    return {"host": "localhost", "port": 8080, "debug": True}
-
-fetch_config()
-# INFO — fetch_config returned dict[len=3]: {'host': 'localhost', 'port': 8080, ...
-```
+Can also be called with arguments: `@log_return(level=logging.INFO, max_length=50)`.
 
 **Parameters:**
 
@@ -50,61 +66,36 @@ fetch_config()
 | `logger` | `Logger \| None` | `None` | Custom logger (defaults to function's module logger) |
 | `max_length` | `int \| None` | `None` | Truncate repr output |
 
-**Supports:** sync functions, async functions, generators, instance/static/class methods, all Python types.
+**Log format:** `{qualname} returned {type_info}: {repr}` — where `type_info` includes `[len=N]` for sized types.
 
-**Log format:** `{qualname} returned {type}[len={n}]: {repr}`
-
-Type info examples:
-
-| Return value | Type info |
-|---|---|
-| `42` | `int` |
-| `"hello"` | `str[len=5]` |
-| `[1, 2, 3]` | `list[len=3]` |
-| `{"a": 1}` | `dict[len=1]` |
-| `None` | `None` |
-| `(generator)` | `generator` |
-
-## Helpers
+---
 
 ### `diff`
 
-Computes a structured diff between two collections of the same type. Supports lists, sets, frozensets, and dicts. Returns an immutable result object.
+Computes a structured diff between two collections of the same type.
+All results are immutable (frozen dataclasses with immutable field types).
 
 ```python
 from jsi_tools import diff
 
-# Lists — multiset semantics
-result = diff([1, 2, 2, 3], [2, 3, 4, 4])
-result.added    # (4, 4)
-result.removed  # (1, 2)
-result.common   # (2, 3)
-
-# Sets
-result = diff({"a", "b", "c"}, {"b", "c", "d"})
-result.added    # frozenset({"d"})
-result.removed  # frozenset({"a"})
-result.common   # frozenset({"b", "c"})
-
-# Dicts — tracks added, removed, changed, and unchanged keys
 result = diff({"a": 1, "b": 2, "c": 3}, {"b": 20, "c": 3, "d": 4})
-result.added     # {"d": 4}
-result.removed   # {"a": 1}
-result.changed   # {"b": (2, 20)}
-result.unchanged # {"c": 3}
+result.added      # {"d": 4}
+result.removed    # {"a": 1}
+result.changed    # {"b": (2, 20)}
+result.unchanged  # {"c": 3}
 ```
 
 **Return types:**
 
 | Input type | Return type | Fields |
-|---|---|---|
+|------------|-------------|--------|
 | `list` | `ListDiff[T]` | `added`, `removed`, `common` (tuples) |
 | `set` / `frozenset` | `SetDiff[T]` | `added`, `removed`, `common` (frozensets) |
 | `dict` | `DictDiff[KT, VT]` | `added`, `removed`, `changed`, `unchanged` (read-only mappings) |
 
-All results are immutable (`frozen` dataclasses with immutable field types).
-
 Raises `TypeError` if types differ, are unsupported, or are tuples (with a hint to convert to list).
+
+---
 
 ## Development
 


### PR DESCRIPTION
## Summary

Resolves #1

### What was done
- Added **Quick Reference** section with tables organized by submodule (Decorators, Helpers, Classes, Utils) for at-a-glance overview
- Consolidated all feature docs under a single **Feature Documentation** section with concise, self-contained subsections
- Reduced verbosity: one example per feature instead of multiple, removed redundant type-info table
- Added placeholder entries ("No classes yet." / "No utils yet.") to show where new items go
- Fixed log format description to accurately reflect `type_info` behavior (includes `[len=N]` only for sized types)
- Updated CHANGELOG.md with an [Unreleased] section

### How it was tested
- Reviewed all code examples against source code for accuracy
- Verified parameter names, types, and defaults match `log_return.py` and `diff.py`
- Confirmed all public exports from `__init__.py` are documented

### Agent team
- **Writer**: Rewrote README with scalable structure (Quick Reference + Feature Documentation)
- **Reviewer**: Verified accuracy against source code, fixed log format description, confirmed spelling/grammar/style

🤖 Generated with [Claude Code](https://claude.com/claude-code)